### PR TITLE
ISX-86: Use public base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG="231224489621.dkr.ecr.us-east-1.amazonaws.com/solr:2.1.4-20250601045430"
+ARG BASE_IMG="ghcr.io/discoverygarden/solr:2.1.5"
 FROM ${BASE_IMG}
 
 RUN rm -rf ${SOLR_CORE_DIR}/conf/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base image for the application to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->