### PR TITLE
SUP-6848: Updating new ocrhighlighting path

### DIFF
--- a/conf/solrconfig_extra.xml
+++ b/conf/solrconfig_extra.xml
@@ -246,4 +246,4 @@
   7.0.0
 -->
   <searchComponent name="tvComponent" class="solr.TermVectorComponent"/>
-<lib dir="/opt/solr_extra_lib/ocrhighlighting/lib" regex=".*\.jar" />
+<lib dir="${solr.hocr.plugin.path:/opt/solr_extra_lib/ocrhighlighting/lib}" regex=".*\.jar" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated Solr configuration to allow a property-based override for the OCR highlighting library location (adds a default fallback). Only the library location mechanism changed; matching behavior and highlighting remain unchanged. No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->